### PR TITLE
Fix response encoding

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -187,7 +187,7 @@ func parseFromTo(from, to string, limit float64) (time.Time, time.Time, error) {
 }
 
 func writeTextResponse(c echo.Context, cLog *chatLog) error {
-	c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlain)
+	c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlainCharsetUTF8)
 	c.Response().WriteHeader(http.StatusOK)
 
 	for _, cMessage := range cLog.Messages {


### PR DESCRIPTION
Logs were being displayed with the wrong charset in browsers (on windows, where UTF-8 is not the default system charset). E.g: https://api.gempir.com/channel/forsen/user/randers00 (scroll down)

Also apparently these constants are deprecated: https://godoc.org/github.com/labstack/echo#pkg-constants

> HTTP methods NOTE: Deprecated, please use the stdlib constants directly instead. 