### PR TITLE
Changed config.admin to support multiple admins

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,7 +14,7 @@ commands, etc. yet, it focuses on logging and providing an api for the logs.
 
 ```
 {
-    "admin": "gempir", // will only respond to this user with !status
+    "admins": ["gempir"], // will only respond to commands executed by these users
     "logsDirectory": "./logs", // the directory to log into
     "username": "gempbot", // bot username (can be justinfan123123 if you don't want to use an account)
     "oauth": "oauthtokenforchat", // bot token can be anything if justinfan123123

--- a/bot/commands.go
+++ b/bot/commands.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (b *Bot) handlePrivateMessage(message twitch.PrivateMessage) {
-	if message.User.Name == b.cfg.Admin {
+	if contains(b.cfg.Admins, message.User.Name) {
 		if strings.HasPrefix(message.Message, "!justlog status") || strings.HasPrefix(message.Message, "!status") {
 			uptime := humanize.TimeSince(b.startTime)
 			b.twitchClient.Say(message.Channel, message.User.DisplayName+", uptime: "+uptime)
@@ -77,4 +77,13 @@ func (b *Bot) handleMessageType(message twitch.PrivateMessage) {
 		b.updateMessageTypesToLog()
 		log.Infof("[bot] setting %s config messageTypes to %v", parts[0], messageTypes)
 	}
+}
+
+func contains(arr []string, str string) bool {
+	for _, x := range arr {
+		if x == str {
+			return true
+		}
+	}
+	return false
 }

--- a/config.json.dist
+++ b/config.json.dist
@@ -1,5 +1,5 @@
 {
-    "admin": "gempir",
+    "admins": ["gempir"],
     "logsDirectory": "./logs",
     "username": "gempbot",
     "oauth": "oauthtokenforchat",

--- a/config/main.go
+++ b/config/main.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Config application configuratin
+// Config application configuration
 type Config struct {
 	configFile            string
 	configFilePermissions os.FileMode
@@ -18,7 +18,7 @@ type Config struct {
 	Username              string                   `json:"username"`
 	OAuth                 string                   `json:"oauth"`
 	ListenAddress         string                   `json:"listenAddress"`
-	Admin                 string                   `json:"admin"`
+	Admins                []string                 `json:"admins"`
 	Channels              []string                 `json:"channels"`
 	ClientID              string                   `json:"clientID"`
 	ClientSecret          string                   `json:"clientSecret"`
@@ -26,7 +26,7 @@ type Config struct {
 	ChannelConfigs        map[string]ChannelConfig `json:"channelConfigs"`
 }
 
-// ChannelConfig config for indiviual channels
+// ChannelConfig config for individual channels
 type ChannelConfig struct {
 	MessageTypes []twitch.MessageType `json:"messageTypes,omitempty"`
 }
@@ -110,7 +110,7 @@ func loadConfiguration(filePath string) *Config {
 		OAuth:          "oauth:777777777",
 		Channels:       []string{},
 		ChannelConfigs: make(map[string]ChannelConfig),
-		Admin:          "gempir",
+		Admins:         []string{"gempir"},
 		LogLevel:       "info",
 	}
 


### PR DESCRIPTION
Closes #52 

- Renamed config option `admin` to ﻿`admins` and also turned it into an array of strings
- Added utility function to `commands.go` to check if array has an element - I'm pretty new to Golang, but I don't think there's an existing thing which can do that
- Fixed couple typos in comments :)
