### PR TITLE
Disable logging for massbans

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
-
-	"github.com/gempir/justlog/config"
 )
 
 func (s *Server) authenticateAdmin(w http.ResponseWriter, r *http.Request) bool {
@@ -18,15 +15,6 @@ func (s *Server) authenticateAdmin(w http.ResponseWriter, r *http.Request) bool 
 	}
 
 	return true
-}
-
-type channelConfigsDeleteRequest struct {
-	MessageTypes bool `json:"messageTypes,omitempty"`
-}
-
-// swagger:model
-type channelConfigsRequest struct {
-	config.ChannelConfig
 }
 
 // swagger:route POST /admin/channelConfigs/{channelID} admin channelConfigs
@@ -50,73 +38,6 @@ type channelConfigsRequest struct {
 //       200:
 //		 400:
 //       405:
-
-// swagger:route DELETE /admin/channelConfigs/{channelID} admin deleteChannelConfigs
-//
-// Will reset the messageTypes logged for a channel
-//
-//     Consumes:
-//     - application/json
-//
-//     Produces:
-//     - application/json
-//     - text/plain
-//
-//     Security:
-//     - api_key:
-//
-//     Schemes: https
-//
-//     Responses:
-//       200:
-//		 400:
-//       405:
-func (s *Server) writeChannelConfigs(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost && r.Method != http.MethodDelete {
-		http.Error(w, "We'll see, we'll see. The winner gets tea.", http.StatusMethodNotAllowed)
-		return
-	}
-
-	channelID := strings.TrimPrefix(r.URL.String(), "/admin/channelConfigs/")
-
-	if _, ok := s.cfg.ChannelConfigs[channelID]; !ok {
-		http.Error(w, "Uhhhhhh... unkown channel", http.StatusBadRequest)
-		return
-	}
-
-	if r.Method == http.MethodDelete {
-		var request channelConfigsDeleteRequest
-
-		err := json.NewDecoder(r.Body).Decode(&request)
-		if err != nil {
-			http.Error(w, "ANYWAYS: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		if request.MessageTypes {
-			s.cfg.ResetMessageTypes(channelID)
-			s.bot.UpdateMessageTypesToLog()
-			writeJSON("Doubters? Reset "+channelID+" messageTypes", http.StatusOK, w, r)
-			return
-		}
-
-		http.Error(w, "Uhhhhhh...", http.StatusBadRequest)
-		return
-	}
-
-	var request channelConfigsRequest
-
-	err := json.NewDecoder(r.Body).Decode(&request)
-	if err != nil {
-		http.Error(w, "ANYWAYS: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	s.cfg.SetMessageTypes(channelID, request.MessageTypes)
-	s.bot.UpdateMessageTypesToLog()
-
-	writeJSON("Doubters? Updated "+channelID+" messageTypes to "+fmt.Sprintf("%v", request.MessageTypes), http.StatusOK, w, r)
-}
 
 type channelsDeleteRequest struct {
 	Channels []string `json:"channels"`
@@ -191,7 +112,7 @@ func (s *Server) writeChannels(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, userData := range data {
-			s.bot.Depart(userData.Login)
+			s.bot.Part(userData.Login)
 		}
 
 		writeJSON(fmt.Sprintf("Doubters? Removed channels %v", request.Channels), http.StatusOK, w, r)

--- a/api/docs.go
+++ b/api/docs.go
@@ -197,18 +197,6 @@ type ChannelUserIdLogsYearMonthParams struct {
 	LogParams
 }
 
-// swagger:parameters channelConfigs
-type ChannelConfigsParameters struct {
-	// in:body
-	Body channelConfigsRequest
-}
-
-// swagger:parameters deleteChannelConfigs
-type DeleteChannelConfigsParameters struct {
-	// in:body
-	Body channelConfigsDeleteRequest
-}
-
 // swagger:parameters addChannels
 type AddChannelsParameters struct {
 	// in:body

--- a/config/main.go
+++ b/config/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	twitch "github.com/gempir/go-twitch-irc/v2"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -25,12 +24,6 @@ type Config struct {
 	ClientID              string                   `json:"clientID"`
 	ClientSecret          string                   `json:"clientSecret"`
 	LogLevel              string                   `json:"logLevel"`
-	ChannelConfigs        map[string]ChannelConfig `json:"channelConfigs"`
-}
-
-// ChannelConfig config for individual channels
-type ChannelConfig struct {
-	MessageTypes []twitch.MessageType `json:"messageTypes,omitempty"`
 }
 
 // NewConfig create configuration from file
@@ -70,34 +63,6 @@ func (cfg *Config) RemoveChannels(channelIDs ...string) {
 	cfg.persistConfig()
 }
 
-// SetMessageTypes sets recorded message types for a channel
-func (cfg *Config) SetMessageTypes(channelID string, messageTypes []twitch.MessageType) {
-	if _, ok := cfg.ChannelConfigs[channelID]; ok {
-		channelCfg := cfg.ChannelConfigs[channelID]
-		channelCfg.MessageTypes = messageTypes
-
-		cfg.ChannelConfigs[channelID] = channelCfg
-	} else {
-		cfg.ChannelConfigs[channelID] = ChannelConfig{
-			MessageTypes: messageTypes,
-		}
-	}
-
-	cfg.persistConfig()
-}
-
-// ResetMessageTypes removed message type option and therefore resets it
-func (cfg *Config) ResetMessageTypes(channelID string) {
-	if _, ok := cfg.ChannelConfigs[channelID]; ok {
-		channelCfg := cfg.ChannelConfigs[channelID]
-		channelCfg.MessageTypes = nil
-
-		cfg.ChannelConfigs[channelID] = channelCfg
-	}
-
-	cfg.persistConfig()
-}
-
 func appendIfMissing(slice []string, i string) []string {
 	for _, ele := range slice {
 		if ele == i {
@@ -129,7 +94,6 @@ func loadConfiguration(filePath string) *Config {
 		Username:       "justinfan777777",
 		OAuth:          "oauth:777777777",
 		Channels:       []string{},
-		ChannelConfigs: make(map[string]ChannelConfig),
 		Admins:         []string{"gempir"},
 		LogLevel:       "info",
 		Archive:        true,

--- a/helix/user.go
+++ b/helix/user.go
@@ -157,8 +157,9 @@ func (c *Client) GetUsersByUsernames(usernames []string) (map[string]UserData, e
 	var filteredUsernames []string
 
 	for _, username := range usernames {
-		if _, ok := userCacheByUsername[strings.ToLower(username)]; !ok {
-			filteredUsernames = append(filteredUsernames, strings.ToLower(username))
+		username = strings.ToLower(username)
+		if _, ok := userCacheByUsername[username]; !ok {
+			filteredUsernames = append(filteredUsernames, username)
 		}
 	}
 
@@ -197,11 +198,12 @@ func (c *Client) GetUsersByUsernames(usernames []string) (map[string]UserData, e
 	result := make(map[string]UserData)
 
 	for _, username := range usernames {
+		username = strings.ToLower(username)
 		if _, ok := userCacheByUsername[username]; !ok {
 			log.Warningf("Could not find username, channel might be banned: %s", username)
 			continue
 		}
-		result[strings.ToLower(username)] = *userCacheByUsername[strings.ToLower(username)]
+		result[username] = *userCacheByUsername[username]
 	}
 
 	return result, nil

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	bot := bot.NewBot(cfg, &helixClient, &fileLogger)
 
-	apiServer := api.NewServer(cfg, bot, &fileLogger, &helixClient, cfg.Channels, assets)
+	apiServer := api.NewServer(cfg, bot, &fileLogger, &helixClient, assets)
 	go apiServer.Init()
 
 	bot.Connect()

--- a/web/build/swagger.json
+++ b/web/build/swagger.json
@@ -39,51 +39,6 @@
           "admin"
         ],
         "operationId": "channelConfigs",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/channelConfigsRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {},
-          "400": {},
-          "405": {}
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "api_key": []
-          }
-        ],
-        "description": "Will reset the messageTypes logged for a channel",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json",
-          "text/plain"
-        ],
-        "schemes": [
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
-        "operationId": "deleteChannelConfigs",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/channelConfigsDeleteRequest"
-            }
-          }
-        ],
         "responses": {
           "200": {},
           "400": {},
@@ -1201,20 +1156,6 @@
       },
       "x-go-package": "github.com/gempir/justlog/api"
     },
-    "ChannelConfig": {
-      "description": "ChannelConfig config for individual channels",
-      "type": "object",
-      "properties": {
-        "messageTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MessageType"
-          },
-          "x-go-name": "MessageTypes"
-        }
-      },
-      "x-go-package": "github.com/gempir/justlog/config"
-    },
     "MessageType": {
       "description": "MessageType different message types possible to receive via IRC",
       "type": "integer",
@@ -1255,16 +1196,6 @@
       },
       "x-go-package": "github.com/gempir/justlog/api"
     },
-    "channelConfigsDeleteRequest": {
-      "type": "object",
-      "properties": {
-        "messageTypes": {
-          "type": "boolean",
-          "x-go-name": "MessageTypes"
-        }
-      },
-      "x-go-package": "github.com/gempir/justlog/api"
-    },
     "channelConfigsJoinRequest": {
       "type": "object",
       "properties": {
@@ -1274,19 +1205,6 @@
             "type": "string"
           },
           "x-go-name": "Channels"
-        }
-      },
-      "x-go-package": "github.com/gempir/justlog/api"
-    },
-    "channelConfigsRequest": {
-      "type": "object",
-      "properties": {
-        "messageTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MessageType"
-          },
-          "x-go-name": "MessageTypes"
         }
       },
       "x-go-package": "github.com/gempir/justlog/api"

--- a/web/public/swagger.json
+++ b/web/public/swagger.json
@@ -39,51 +39,6 @@
           "admin"
         ],
         "operationId": "channelConfigs",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/channelConfigsRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {},
-          "400": {},
-          "405": {}
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "api_key": []
-          }
-        ],
-        "description": "Will reset the messageTypes logged for a channel",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json",
-          "text/plain"
-        ],
-        "schemes": [
-          "https"
-        ],
-        "tags": [
-          "admin"
-        ],
-        "operationId": "deleteChannelConfigs",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/channelConfigsDeleteRequest"
-            }
-          }
-        ],
         "responses": {
           "200": {},
           "400": {},
@@ -1201,20 +1156,6 @@
       },
       "x-go-package": "github.com/gempir/justlog/api"
     },
-    "ChannelConfig": {
-      "description": "ChannelConfig config for individual channels",
-      "type": "object",
-      "properties": {
-        "messageTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MessageType"
-          },
-          "x-go-name": "MessageTypes"
-        }
-      },
-      "x-go-package": "github.com/gempir/justlog/config"
-    },
     "MessageType": {
       "description": "MessageType different message types possible to receive via IRC",
       "type": "integer",
@@ -1255,16 +1196,6 @@
       },
       "x-go-package": "github.com/gempir/justlog/api"
     },
-    "channelConfigsDeleteRequest": {
-      "type": "object",
-      "properties": {
-        "messageTypes": {
-          "type": "boolean",
-          "x-go-name": "MessageTypes"
-        }
-      },
-      "x-go-package": "github.com/gempir/justlog/api"
-    },
     "channelConfigsJoinRequest": {
       "type": "object",
       "properties": {
@@ -1274,19 +1205,6 @@
             "type": "string"
           },
           "x-go-name": "Channels"
-        }
-      },
-      "x-go-package": "github.com/gempir/justlog/api"
-    },
-    "channelConfigsRequest": {
-      "type": "object",
-      "properties": {
-        "messageTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/MessageType"
-          },
-          "x-go-name": "MessageTypes"
         }
       },
       "x-go-package": "github.com/gempir/justlog/api"


### PR DESCRIPTION
Bot lists are used to massban in a lot of chats. That leads to a lot of logs of just accounts that never typed anything but get 1 log line for their ban message. 

