### PR TITLE
fix emote parsing in strings containing emoji

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "react-query": "^3.21.0",
     "react-scripts": "^4.0.3",
     "react-window": "^1.8.6",
+    "runes": "^0.4.3",
     "swagger-ui-react": "^4.0.0-beta.4",
     "typescript": "^4.0.3",
     "web-vitals": "^2.1.0"
@@ -52,6 +53,7 @@
     "@types/react-window": "^1.8.2",
     "@types/styled-components": "^5.1.4",
     "@types/swagger-ui-react": "^3.35.0",
+    "@types/runes": "^0.4.1",
     "styled-components": "^5.2.1"
   }
 }

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { store } from "../store";
 import { LogMessage } from "../types/log";
 import { ThirdPartyEmote } from "../types/ThirdPartyEmote";
+import runes from "runes";
 
 const MessageContainer = styled.div`
 
@@ -40,9 +41,10 @@ export function Message({ message, thirdPartyEmotes }: { message: LogMessage, th
 		renderMessagePrefix = `${message.tags['system-msg']} `;
 	}
 
+	const messageTextEmoji = runes(messageText);
 
-	for (let x = 0; x <= messageText.length; x++) {
-		const c = messageText[x];
+	for (let x = 0; x <= messageTextEmoji.length; x++) {
+		const c = messageTextEmoji[x];
 
 		replaced = false;
 
@@ -63,7 +65,7 @@ export function Message({ message, thirdPartyEmotes }: { message: LogMessage, th
 		}
 
 		if (!replaced) {
-			if (c !== " " && x !== messageText.length) {
+			if (c !== " " && x !== messageTextEmoji.length) {
 				buffer += c;
 				continue;
 			}

--- a/web/src/hooks/useLog.ts
+++ b/web/src/hooks/useLog.ts
@@ -3,6 +3,7 @@ import { useQuery } from "react-query";
 import { getUserId, isUserId } from "../services/isUserId";
 import { store } from "../store";
 import { Emote, LogMessage, UserLogResponse } from "../types/log";
+import runes from "runes";
 
 
 
@@ -67,12 +68,12 @@ function parseEmotes(messageText: string, emotes: string | undefined): Array<Emo
 
             const startIndex = Number(startPos);
             const endIndex = Number(endPos) + 1;
-
+            
             parsed.push({
                 id,
                 startIndex: startIndex,
                 endIndex: endIndex,
-                code: messageText.substr(startIndex, endIndex - startIndex)
+                code: runes.substr(messageText, startIndex, endIndex - startIndex + 1)
             });
         }
     }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2650,6 +2650,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/runes@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/runes/-/runes-0.4.1.tgz#ec16e8d73dd1acfa09aca3b6a9180dfef45045ae"
+  integrity sha512-wb2qEPRr/BXKB1xx7S5OzbnZmqIGRPrw0SjBJYnLA+l5DEGmyw7veFXQ0Cko/gotDTB+yGpsZOAkLDWZTyJo6w==
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -11214,6 +11219,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+runes@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/runes/-/runes-0.4.3.tgz#32f7738844bc767b65cc68171528e3373c7bb355"
+  integrity sha512-K6p9y4ZyL9wPzA+PMDloNQPfoDGTiFYDvdlXznyGKgD10BJpcAosvATKrExRKOrNLgD8E7Um7WGW0lxsnOuNLg==
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"


### PR DESCRIPTION
Fixes #99

![image](https://user-images.githubusercontent.com/19672127/142056049-edc25053-78d3-400f-9321-f9edfecade73.png)


Emojis are multiple characters so we can't just iterate through the characters, `runes` splits the string into an array of characters for us while respecting emoji boundaries. 