### PR TITLE
Fix a crash that would occur upon typing prefix with no command

### DIFF
--- a/bot/commands.go
+++ b/bot/commands.go
@@ -25,6 +25,9 @@ func (b *Bot) handlePrivateMessageCommands(message twitch.PrivateMessage) {
 	}
 
 	args := strings.Fields(message.Message[len(commandPrefix):])
+	if len(args) < 1 {
+		return
+	}
 	commandName := args[0]
 	args = args[1:]
 


### PR DESCRIPTION
Typing `!justlog` or `!justlog ` would make justlog crash.
I think I introduced it myself in #123, can't find a better way to handle this.
