### PR TITLE
Use HTTP Not Found rather than Internal server error for logs not found

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -213,7 +213,7 @@ func (s *Server) routeLogs(w http.ResponseWriter, r *http.Request) bool {
 
 	if err != nil {
 		log.Error(err)
-		http.Error(w, "could not load logs", http.StatusInternalServerError)
+		http.Error(w, "could not load logs", http.StatusNotFound)
 		return true
 	}
 


### PR DESCRIPTION
IMO 404 is more appropriate because it implies the logs just not existing rather than a strict failure