### PR TITLE
Add functionality for channel-wide random messages

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -7,6 +7,48 @@ import (
 	"github.com/gempir/go-twitch-irc/v3"
 )
 
+// RandomQuoteJSON response when request a random message
+type RandomChannelQuoteJSON struct {
+	Channel     string    `json:"channel"`
+	Username    string    `json:"username"`
+	DisplayName string    `json:"displayName"`
+	Message     string    `json:"message"`
+	Timestamp   timestamp `json:"timestamp"`
+}
+
+// swagger:route GET /channel/{channel}/random logs randomChannelLog
+//
+// Get a random line from the entire channel log's history
+//
+//     Produces:
+//     - application/json
+//     - text/plain
+//
+//     Responses:
+//       200: chatLog
+
+// swagger:route GET /channelid/{channelid}/random logs randomChannelLog
+//
+// Get a random line from the entire channel log's history
+//
+//     Produces:
+//     - application/json
+//     - text/plain
+//
+//     Responses:
+//       200: chatLog
+func (s *Server) getChannelRandomQuote(request logRequest) (*chatLog, error) {
+	rawMessage, err := s.fileLogger.ReadRandomMessageForChannel(request.channelid)
+	if err != nil {
+		return &chatLog{}, err
+	}
+	parsedMessage := twitch.ParseMessage(rawMessage)
+
+	chatMsg := createChatMessage(parsedMessage)
+
+	return &chatLog{Messages: []chatMessage{chatMsg}}, nil
+}
+
 // swagger:route GET /channel/{channel} logs channelLogs
 //
 // Get entire channel logs of current day

--- a/api/logrequest.go
+++ b/api/logrequest.go
@@ -103,6 +103,8 @@ func (s *Server) newLogRequestFromURL(r *http.Request) (logRequest, error) {
 		request.time.day = params[5]
 	} else if request.isUserRequest && len(params) == 6 && params[5] == "random" {
 		request.time.random = true
+	} else if request.isChannelRequest && len(params) == 4 && params[3] == "random" {
+		request.time.random = true
 	} else {
 		if request.isChannelRequest {
 			request.time.year = fmt.Sprintf("%d", time.Now().Year())

--- a/api/server.go
+++ b/api/server.go
@@ -195,10 +195,9 @@ func (s *Server) routeLogs(w http.ResponseWriter, r *http.Request) bool {
 
 	var logs *chatLog
 	if request.time.random {
-	    if requst.isUserRequest {
+	    if request.isUserRequest {
 		    logs, err = s.getRandomQuote(request)
-	    }
-	    else {
+	    } else {
 		    logs, err = s.getChannelRandomQuote(request)
 	    }
 	} else if request.time.from != "" && request.time.to != "" {

--- a/api/server.go
+++ b/api/server.go
@@ -195,7 +195,12 @@ func (s *Server) routeLogs(w http.ResponseWriter, r *http.Request) bool {
 
 	var logs *chatLog
 	if request.time.random {
-		logs, err = s.getRandomQuote(request)
+	    if requst.isUserRequest {
+		    logs, err = s.getRandomQuote(request)
+	    }
+	    else {
+		    logs, err = s.getChannelRandomQuote(request)
+	    }
 	} else if request.time.from != "" && request.time.to != "" {
 		if request.isUserRequest {
 			logs, err = s.getUserLogsRange(request)

--- a/filelog/channellog.go
+++ b/filelog/channellog.go
@@ -163,8 +163,6 @@ func (l *Logger) ReadRandomMessageForChannel(channelID string) (string, error) {
 	randomDayIndex := rand.Intn(len(days))
 	randomDayPath := days[randomDayIndex] + "/channel.txt"
 
-	log.Infof("path %s", randomDayPath)
-
 	f, _ := os.Open(randomDayPath)
 	scanner := bufio.NewScanner(f)
 


### PR DESCRIPTION
Added new endpoints for requesting a random message from an entire channel, rather than for a specific user in a specific channel:
- `channel/<channel>/random`
- `channelid/<channelid>/random`

User-specific random lines load all log files and save their lines into a slice, then pick one at random. This isn't really feasible for an entire channel, so this implementation takes a different approach:
- creates a list of all log files paths
- picks one at random
- loads that one file into an array and picks a random line, similar to user-specific implementation

This isn't truly random, but I believe it is "random enough" for this purpose.