### PR TITLE
Better visibility of emotes name

### DIFF
--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -56,6 +56,7 @@ export function Message({ message, thirdPartyEmotes }: { message: LogMessage, th
 						className="emote"
 						key={x}
 						alt={emote.code}
+						title={emote.code}
 						src={`https://static-cdn.jtvnw.net/emoticons/v2/${emote.id}/default/dark/1.0`}
 					/>);
 					x += emote.endIndex - emote.startIndex - 1;
@@ -77,6 +78,7 @@ export function Message({ message, thirdPartyEmotes }: { message: LogMessage, th
 						className="emote"
 						key={x}
 						alt={emote.code}
+						title={emote.code}
 						src={emote.urls.small}
 					/>);
 					emoteFound = true;


### PR DESCRIPTION
This change allows the name of the emote to be visible when hovering over it

**Before:**
![Before](https://user-images.githubusercontent.com/57513632/200038780-39b34be2-9c39-497a-bb8b-2bc4b90738f4.png)

**After:**
![image](https://user-images.githubusercontent.com/57513632/200039236-7c2fef84-f363-43d4-9d73-d01dcfb50abd.png)
