### PR TITLE
Check if emotes exist in 7tv api response

### DIFF
--- a/web/src/hooks/use7tvChannelEmotes.ts
+++ b/web/src/hooks/use7tvChannelEmotes.ts
@@ -29,7 +29,7 @@ export function use7tvChannelEmotes(channelId: string): Array<ThirdPartyEmote> {
 
 	const emotes = [];
 
-	for (const channelEmote of data?.emote_set.emotes ?? []) {
+	for (const channelEmote of data?.emote_set?.emotes ?? []) {
 		const webpEmotes = channelEmote.data.host.files.filter(i => i.format === 'WEBP');
 		const emoteURL = channelEmote.data.host.url;
 		emotes.push({

--- a/web/src/types/7tv.ts
+++ b/web/src/types/7tv.ts
@@ -6,7 +6,7 @@ interface StvGlobal {
 }
 
 interface StvChannel {
-    emote_set: StvEmoteSet;
+    emote_set: StvEmoteSet | null;
 }
 
 interface StvEmoteSet {


### PR DESCRIPTION
This closes issue #194 

emote_set can be null in 7tv's api response when the user has no emotes added but has logged in before. it's now caught properly.